### PR TITLE
Fix failing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_install:
   - gem install compass
   - npm install -g npm@2
-  - npm install -g grunt-cli bower
+  - npm install -g bower
 install:
   - npm install
   - bower install


### PR DESCRIPTION
The latest version of grunt (1.1.0) requires node >= 8.
For now, use the older grunt and grunt-cli versions already specified in package.lock