### PR TITLE
Make dist destination configurable

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
   // Configurable paths for the application
   var appConfig = {
     app: require('./bower.json').appPath || 'app',
-    dist: 'dist',
+    dist: grunt.option('dist') || 'dist',
     basePath: loadConfig().appConfig.basePath || '/'
   };
 


### PR DESCRIPTION
### Added

- Added `dist` option to `grunt build` to set the location of the dist folder. Defaults to `dist` for backwards compatibility.