### PR TITLE
PROJ-154 - Replaced ascii code with css code

### DIFF
--- a/app/styles/components/_login.scss
+++ b/app/styles/components/_login.scss
@@ -29,13 +29,14 @@ $light:   #FFF;
   list-style: none;
 
   li {
-    padding-left: 30px;
+    padding-left: 20px;
     position: relative;
 
     &:before {
       color: #A3C351;
-      content: "\xE2";
+      content: "\2713";
       position: absolute;
+      font-weight: bold;
       top: 0;
       left: 0;
     }


### PR DESCRIPTION
### Fixed
- Replaced ascii code with css code
- Slightly decreased the padding-left since it looks better IMO

<img width="1188" alt="Screenshot 2021-01-14 at 09 22 28" src="https://user-images.githubusercontent.com/9402377/104563904-8d1d2c00-564a-11eb-860d-e17c45bfc09f.png">


---
Ticket: https://jira.uitdatabank.be/browse/PROJ-154
